### PR TITLE
Remove __future__ annotations from settings.py

### DIFF
--- a/src/scikit_build_core_conan/build/settings.py
+++ b/src/scikit_build_core_conan/build/settings.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass, field
 
 


### PR DESCRIPTION
Since the latest update I started getting this error:
<details>
<summary>Error message and stack trace</summary>

  error: subprocess-exited-with-error
  
  × Building wheel for md_tsdf_native_modules (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [28 lines of output]
        + Exception Group Traceback (most recent call last):
        |   File "/home/deivse/miniforge3/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
        |     main()
        |   File "/home/deivse/miniforge3/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
        |     json_out["return_val"] = hook(**hook_input["kwargs"])
        |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        |   File "/home/deivse/miniforge3/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 280, in build_wheel
        |     return _build_backend().build_wheel(
        |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        |   File "/tmp/pip-build-env-otviykym/overlay/lib/python3.12/site-packages/scikit_build_core_conan/build/__init__.py", line 31, in build_wheel
        |     return _build_wheel_impl(wheel_directory, config_settings, metadata_directory, editable=False)
        |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        |   File "/tmp/pip-build-env-otviykym/overlay/lib/python3.12/site-packages/scikit_build_core_conan/build/wheel.py", line 250, in _build_wheel_impl
        |     ).convert_target(ConanSettings)
        |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        |   File "/tmp/pip-build-env-otviykym/overlay/lib/python3.12/site-packages/scikit_build_core/settings/sources.py", line 632, in convert_target
        |     raise ExceptionGroup(msg, errors)
        | ExceptionGroup: Failed converting tool.scikit-build-core-conan (1 sub-exception)
        +-+---------------- 1 ----------------
          | Traceback (most recent call last):
          |   File "/tmp/pip-build-env-otviykym/overlay/lib/python3.12/site-packages/scikit_build_core/settings/sources.py", line 601, in convert_target
          |     tmp = source.convert(simple, field.type)
          |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          |   File "/tmp/pip-build-env-otviykym/overlay/lib/python3.12/site-packages/scikit_build_core/settings/sources.py", line 541, in convert
          |     raise TypeError(msg)
          | TypeError: Can't convert target list[str] | str
          | Field tool.scikit-build-core-conan.build
          +------------------------------------
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.

</details>

After some digging I realized that it's because scikit-build-core can't handle deferred evaluation of annotations, at least using scikit-build-core==0.11.6. 